### PR TITLE
fix: userId 기반 모델 응답 라우팅 및 per-user 시퀀스 분리

### DIFF
--- a/src/controllers/modelController.js
+++ b/src/controllers/modelController.js
@@ -28,9 +28,10 @@ export const connectToModel = (wss) => {
         const dataString = message.data.toString();
         try {
             const data = JSON.parse(dataString);
-            console.log(`Model server response: ${JSON.stringify(data)}`);
+            const targetUserId = data.userId;
+            console.log(`Model server response (userId: ${targetUserId}): ${data.text}`);
             wss.clients.forEach(client => {
-                if (client.readyState === WebSocket.OPEN) {
+                if (client.readyState === WebSocket.OPEN && client.userId === targetUserId) {
                     client.send(JSON.stringify({
                         type: 'model_response',
                         text: data.text

--- a/src/controllers/webSocketController.js
+++ b/src/controllers/webSocketController.js
@@ -104,6 +104,9 @@ export const handleWebSocketConnection = (ws, req) => {
                                     }
                                 });
                             }
+                            if (modelWs && modelWs.readyState === WebSocket.OPEN) {
+                                modelWs.send(JSON.stringify({ type: 'stop_stream', userId }));
+                            }
                             break;
                         }
                         case 'subscribe': {
@@ -170,18 +173,14 @@ export const handleWebSocketConnection = (ws, req) => {
                 // Handling binary data (video chunk)
                 if (modelWs && modelWs.readyState === WebSocket.OPEN) {
                     const publishingUserId = ws.userId;
-                    const width = 640;
-                    const height = 480;
-                    const mimeType = userIdToMimeType.get(publishingUserId); // 맵에서 가져옴
-                    modelWs.send(data, { binary: true });
-                    console.log("@#@# sended data (width, height, mimeType)", width, height, mimeType)
-                    // modelWs.send(JSON.stringify({
-                    //     type: 'stream_config', // 새로운 타입으로 정의
-                    //     userId,
-                    //     mimeType,
-                    //     width,
-                    //     height
-                    // }));
+                    // Prepend 4-byte userId header so model can route per-user sequences
+                    const userIdBytes = Buffer.from(publishingUserId, 'utf8');
+                    const header = Buffer.allocUnsafe(4);
+                    header.writeUInt32BE(userIdBytes.length, 0);
+                    const rawData = data instanceof Buffer ? data : Buffer.from(data);
+                    const payload = Buffer.concat([header, userIdBytes, rawData]);
+                    modelWs.send(payload, { binary: true });
+                    console.log(`@#@# 프레임 전송 (userId: ${publishingUserId}, size: ${rawData.length}B)`);
                 }
                 console.log(`@#@# ws.userID, userIdToSubscribers: ${!!ws.userId} ${userIdToSubscribers.has(ws.userId)}`);
                 if (ws.userId && userIdToSubscribers.has(ws.userId)) {


### PR DESCRIPTION
### Issue
#3 

### 변경 사항 요약
- 바이너리 프레임에 4바이트 userId 헤더를 추가해 모델이 사용자별 시퀀스를 분리 유지
- 모델 응답에 userId를 포함시키고, 스트리밍 서버가 해당 사용자 클라이언트에만 전달
- Chrome Extension의 WebSocket URL 템플릿 리터럴 버그 수정

### 변경 파일
- `streaming-server/src/controllers/webSocketController.js`
- `streaming-server/src/controllers/modelController.js`
- `sign-language-korean/main.py`
- `chrome-extension/src/controllers/streamController.js`

### 상세 내용

#### 바이너리 프레임 프로토콜 (신규)
[ 4 bytes: userId length (uint32 big-endian) ]
[ N bytes: userId (UTF-8) ]
[ remaining: JPEG frame data ]



#### webSocketController.js
- binary 수신 시 4바이트 userId 헤더 + userId bytes를 프레임 앞에 prepend
- `stop_stream` 처리 시 모델 서버에도 `{type: 'stop_stream', userId}` 전송
  (모델이 해당 userId의 deque/holistic 정리 가능)

#### modelController.js
- `wss.clients.forEach` broadcast → `client.userId === targetUserId` 조건부 전달
- 모델 응답의 `userId` 필드를 사용해 특정 클라이언트에만 라우팅

#### main.py
- `import json` 추가
- 단일 `sequence_data` deque → `user_sequences: dict[str, deque]`로 교체
- 단일 `holistic` → `user_holistics: dict[str, Holistic]`로 교체
- `await websocket.receive()` 로 텍스트(JSON 제어 메시지)와 바이너리 통합 처리
- `stream_config`: userId별 deque + Holistic 초기화
- `stop_stream`: 해당 userId 리소스 즉시 해제
- binary: 헤더에서 userId 파싱 → per-userId deque에 프레임 추가 → 예측
- 응답: `{"userId": user_id, "text": result_text}`
- lazy 초기화: stream_config 없이 프레임 도착 시에도 자동 초기화
- finally: 연결 종료 시 모든 userId Holistic 리소스 정리

#### streamController.js (bonus)
- `'wss://...?userId=${this.userId}'` (single quote) → `` `wss://...?userId=${this.userId}` `` (backtick)
  으로 수정하여 userId가 실제로 URL에 삽입되도록 수정

### 테스트 방법
1. 2명의 Google Meet 참가자 선택 후 해석 시작
2. 모델 서버 로그에서 `[user_1] 시퀀스 및 MediaPipe 초기화`, `[user_2] 시퀀스 및 MediaPipe 초기화` 확인
3. 스트리밍 서버 로그에서 `Model server response (userId: user_1)` 형태 확인
4. 각 참가자의 번역 결과가 해당 Chrome Extension에만 전달되는지 확인

### 한계 (향후 개선 사항)
현재 Chrome Extension은 모든 참가자 영상을 하나의 WebSocket 연결로 전송한다.
완전한 다중 사용자 지원을 위해서는 참가자별 별도 WebSocket 연결이 필요하다.